### PR TITLE
Add proposed text for 7 day ballot shortening

### DIFF
--- a/source/jesp.adoc
+++ b/source/jesp.adoc
@@ -15,6 +15,7 @@ The Jakarta EE Specification Committee hereby adopts the https://www.eclipse.org
 .. Service Release Review: 14 calendar days; and
 .. JESP Update: 7 calendar days.
 
+. Any specification committee approval ballot may be closed after 7 calendar days if all working group members or member representatives, elligible to vote, have cast their vote. Otherwise, all ballot durations shall be as listed above.
 . A ballot will be declared invalid and concluded immediately in the event that the Specifiation Team withdraws from the corresponding review.
 . Specification Projects must engage in at least one Progress or Release Review  per year while in active development.
 

--- a/source/jesp.adoc
+++ b/source/jesp.adoc
@@ -4,18 +4,20 @@ version 1.3. Effective April 5/2022
 
 The Jakarta EE Specification Process (JESP) is concerned with the Specification Process as it applies to Specification Projects operating under the purview of the Jakarta EE Working Group. 
 
-The Jakarta EE Specification Committee hereby adopts the https://www.eclipse.org/projects/efsp?version=1.2[Eclipse Foundation Specification Process v1.2] (EFSP) as the Jakarta EE Specification Process with the following modifications:
+The Jakarta EE Specification Committee hereby adopts the https://www.eclipse.org/projects/efsp?version=1.3[Eclipse Foundation Specification Process v1.3] (EFSP) as the Jakarta EE Specification Process with the following modifications:
 
 . Any modification to or revision of this Jakarta EE Specification Process, including the adoption of a new version of the EFSP, must be approved by a Super-majority of the Specification Committee, including a Super-majority of the Strategic Members of the Jakarta EE Working Group, in addition to any other ballot requirements set forth in the EFSP.
-. All specification committee approval ballot periods will have the minimum duration as outlined below (notwithstanding the exception process defined by the EFSP, these periods may not be shortened)
+. All specification committee approval ballot periods will have durations as outlined below (notwithstanding the exception process defined by the EFSP)
 .. Creation Review: 7 calendar days;
 .. Plan Review:  7 calendar days;
 .. Progress Review: 14 calendar days;
 .. Release Review: 14 calendar days;
 .. Service Release Review: 14 calendar days; and
 .. JESP Update: 7 calendar days.
+. Each 7-day ballot will end after 7 days. Each 14-day ballot will conclude when either of the following occurs:
+.. A minimum of 7 days have elapsed and all eligible members have voted
+.. The 14 day ballot period has concluded
 
-. Any specification committee approval ballot may be closed after 7 calendar days if all working group members or member representatives, eligible to vote, have cast their vote. Otherwise, all ballot durations shall be as listed above.
 . A ballot will be declared invalid and concluded immediately in the event that the Specifiation Team withdraws from the corresponding review.
 . Specification Projects must engage in at least one Progress or Release Review  per year while in active development.
 

--- a/source/jesp.adoc
+++ b/source/jesp.adoc
@@ -15,7 +15,7 @@ The Jakarta EE Specification Committee hereby adopts the https://www.eclipse.org
 .. Service Release Review: 14 calendar days; and
 .. JESP Update: 7 calendar days.
 
-. Any specification committee approval ballot may be closed after 7 calendar days if all working group members or member representatives, elligible to vote, have cast their vote. Otherwise, all ballot durations shall be as listed above.
+. Any specification committee approval ballot may be closed after 7 calendar days if all working group members or member representatives, eligible to vote, have cast their vote. Otherwise, all ballot durations shall be as listed above.
 . A ballot will be declared invalid and concluded immediately in the event that the Specifiation Team withdraws from the corresponding review.
 . Specification Projects must engage in at least one Progress or Release Review  per year while in active development.
 


### PR DESCRIPTION
If all members have cast vote, allow 14 day ballots to conclude after all members have voted. Discussed and, I believe achieved consensus at Spec. committee meetings.